### PR TITLE
fix: bump Fable.Core to 5.0.0-rc.2 and ShipIt to 2.0.2

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -24,7 +24,7 @@
       "rollForward": false
     },
     "easybuild.shipit": {
-      "version": "2.0.0",
+      "version": "2.0.2",
       "commands": [
         "shipit"
       ],

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -5,7 +5,7 @@ storage: none
 framework: netstandard2.0, netstandard2.1, net6.0, net8.0, net9.0, net10.0
 
 nuget FSharp.Core >= 5.0.0 lowest_matching: true
-nuget Fable.Core 5.0.0-rc.1
+nuget Fable.Core 5.0.0-rc.2
 
 group Test
     source https://api.nuget.org/v3/index.json
@@ -13,7 +13,7 @@ group Test
     framework: net9.0
 
     nuget FSharp.Core
-    nuget Fable.Core 5.0.0-rc.1
+    nuget Fable.Core 5.0.0-rc.2
     nuget Microsoft.NET.Test.Sdk ~> 16
     nuget xunit ~> 2
     nuget xunit.runner.visualstudio ~> 2
@@ -24,7 +24,7 @@ group Examples
     framework: net10.0
 
     nuget FSharp.Core
-    nuget Fable.Core 5.0.0-rc.1
+    nuget Fable.Core 5.0.0-rc.2
     nuget Feliz.ViewEngine
     nuget Zanaptak.TypedCssClasses
     nuget FSharp.Control.AsyncRx

--- a/paket.lock
+++ b/paket.lock
@@ -2,7 +2,7 @@ STORAGE: NONE
 RESTRICTION: || (== net10.0) (== net6.0) (== net8.0) (== net9.0) (== netstandard2.0) (== netstandard2.1)
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    Fable.Core (5.0.0-rc.1)
+    Fable.Core (5.0.0-rc.2)
       FSharp.Core (>= 4.7.2)
     FSharp.Core (5.0)
 
@@ -11,7 +11,7 @@ STORAGE: NONE
 RESTRICTION: == net10.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    Fable.Core (5.0.0-rc.1)
+    Fable.Core (5.0.0-rc.2)
       FSharp.Core (>= 4.7.2)
     Feliz.ViewEngine (1.0.3)
       FSharp.Core (>= 4.7)
@@ -26,7 +26,7 @@ STORAGE: NONE
 RESTRICTION: == net9.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    Fable.Core (5.0.0-rc.1)
+    Fable.Core (5.0.0-rc.2)
       FSharp.Core (>= 4.7.2)
     FSharp.Core (11.0.100)
     Microsoft.CodeCoverage (18.3)


### PR DESCRIPTION
## Summary

- Bump `Fable.Core` to [5.0.0-rc.2](https://www.nuget.org/packages/Fable.Core/5.0.0-rc.2)
- Bump `EasyBuild.ShipIt` to 2.0.2

Uses `fix:` so that merging triggers the ShipIt release workflow and cuts the next `5.0.0-rc.*` release. Since the last tagged release (`v5.0.0-rc.2`), the unreleased range on `main` has been `chore:`-only, which ShipIt ignores for version bumps — this PR gives it a patch-worthy commit to act on.

## Test plan

- [ ] `just build` succeeds against Fable.Core 5.0.0-rc.2
- [ ] `just test-python` passes
- [ ] After merge, the `ShipIt - Pull Request` job opens a `chore: release ...` PR
- [ ] Merging that release PR publishes the package to NuGet

🤖 Generated with [Claude Code](https://claude.com/claude-code)