### PR TITLE
chore: anchor CHANGELOG with 5.0.0-rc.2 entry so ShipIt bumps to rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ name: Fable.Python
 
 All notable changes to this project will be documented in this file.
 
+## 5.0.0-rc.2 - 2026-03-09
+
+Last release on the legacy tag-based workflow. Matches [Fable.Python 5.0.0-rc.2 on NuGet](https://www.nuget.org/packages/Fable.Python/5.0.0-rc.2).
+
 ## [5.0.0-alpha.21.5](https://github.com/fable-compiler/Fable.Python/compare/v5.0.0-alpha.21.4...v5.0.0-alpha.21.5) (2025-12-21)
 
 ### Bug Fixes


### PR DESCRIPTION
## Summary

Without a header in ShipIt's `## X.Y.Z - date` format, ShipIt can't read the current version from `CHANGELOG.md` and falls back to `0.0.0`, proposing `chore: release Fable.Python@0.0.1-rc.1` instead of the expected `5.0.0-rc.3`.

This seeds the changelog with a ShipIt-parseable entry for the last released version ([Fable.Python 5.0.0-rc.2 on NuGet](https://www.nuget.org/packages/Fable.Python/5.0.0-rc.2)) so the next release lands on `5.0.0-rc.3`.

## Test plan

- [ ] After merge, the `ShipIt - Pull Request` job proposes `chore: release Fable.Python@5.0.0-rc.3`
- [ ] Merging that release PR publishes `Fable.Python 5.0.0-rc.3` to NuGet

🤖 Generated with [Claude Code](https://claude.com/claude-code)