### PR TITLE
ci: fix Python version from 3.10 to 3.12 in build-and-test workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v5


### PR DESCRIPTION
## Summary

- Bumps `python-version` in CI from `3.10` to `3.12` to match `pyproject.toml` `requires-python = ">= 3.12, < 4"`
- CI was testing against an unsupported Python version

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)