### PR TITLE
build: relax Fable.Core pin to >= 5.0.0-rc.1

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -5,7 +5,7 @@ storage: none
 framework: netstandard2.0, netstandard2.1, net6.0, net8.0, net9.0, net10.0
 
 nuget FSharp.Core >= 5.0.0 lowest_matching: true
-nuget Fable.Core 5.0.0-rc.2
+nuget Fable.Core >= 5.0.0-rc.1 lowest_matching: true
 
 group Test
     source https://api.nuget.org/v3/index.json
@@ -13,7 +13,7 @@ group Test
     framework: net9.0
 
     nuget FSharp.Core
-    nuget Fable.Core 5.0.0-rc.2
+    nuget Fable.Core >= 5.0.0-rc.1 lowest_matching: true
     nuget Microsoft.NET.Test.Sdk ~> 16
     nuget xunit ~> 2
     nuget xunit.runner.visualstudio ~> 2
@@ -24,7 +24,7 @@ group Examples
     framework: net10.0
 
     nuget FSharp.Core
-    nuget Fable.Core 5.0.0-rc.2
+    nuget Fable.Core >= 5.0.0-rc.1 lowest_matching: true
     nuget Feliz.ViewEngine
     nuget Zanaptak.TypedCssClasses
     nuget FSharp.Control.AsyncRx

--- a/paket.lock
+++ b/paket.lock
@@ -2,7 +2,7 @@ STORAGE: NONE
 RESTRICTION: || (== net10.0) (== net6.0) (== net8.0) (== net9.0) (== netstandard2.0) (== netstandard2.1)
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    Fable.Core (5.0.0-rc.2)
+    Fable.Core (5.0.0-rc.1)
       FSharp.Core (>= 4.7.2)
     FSharp.Core (5.0)
 
@@ -11,7 +11,7 @@ STORAGE: NONE
 RESTRICTION: == net10.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    Fable.Core (5.0.0-rc.2)
+    Fable.Core (5.0.0-rc.1)
       FSharp.Core (>= 4.7.2)
     Feliz.ViewEngine (1.0.3)
       FSharp.Core (>= 4.7)
@@ -26,22 +26,22 @@ STORAGE: NONE
 RESTRICTION: == net9.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    Fable.Core (5.0.0-rc.2)
+    Fable.Core (5.0.0-rc.1)
       FSharp.Core (>= 4.7.2)
     FSharp.Core (11.0.100)
-    Microsoft.CodeCoverage (18.3)
+    Microsoft.CodeCoverage (18.4)
     Microsoft.NET.Test.Sdk (16.11)
       Microsoft.CodeCoverage (>= 16.11)
       Microsoft.TestPlatform.TestHost (>= 16.11)
-    Microsoft.TestPlatform.ObjectModel (18.3)
+    Microsoft.TestPlatform.ObjectModel (18.4)
       System.Reflection.Metadata (>= 8.0)
-    Microsoft.TestPlatform.TestHost (18.3)
-      Microsoft.TestPlatform.ObjectModel (>= 18.3)
+    Microsoft.TestPlatform.TestHost (18.4)
+      Microsoft.TestPlatform.ObjectModel (>= 18.4)
       Newtonsoft.Json (>= 13.0.3)
     Newtonsoft.Json (13.0.4)
-    System.Collections.Immutable (10.0.5)
-    System.Reflection.Metadata (10.0.5)
-      System.Collections.Immutable (>= 10.0.5)
+    System.Collections.Immutable (10.0.6)
+    System.Reflection.Metadata (10.0.6)
+      System.Collections.Immutable (>= 10.0.6)
     xunit (2.9.3)
       xunit.analyzers (>= 1.18)
       xunit.assert (>= 2.9.3)


### PR DESCRIPTION
## Summary
- Change `Fable.Core` constraint in `paket.dependencies` from exact `5.0.0-rc.2` to `>= 5.0.0-rc.1 lowest_matching: true` (all three groups: Main, Test, Examples).
- Paket's exact pin gets packed into the nupkg as `[5.0.0-rc.2]`, which forced consumers on newer Fable.Core RCs into a resolver conflict. Switching to a minimum-version constraint matches how `Fable.Browser.*`, `Fable.Promise`, and `Fable.Solid` express their `Fable.Core` dependency.
- Floor set at rc.1 (not rc.2) after confirming the bindings don't use any rc.2-specific API.

## Test plan
- [x] `just build` succeeds
- [x] `just test-python` — 317/317 pass
- [x] `paket.lock` regenerated; Fable.Core resolves to rc.1 under `lowest_matching`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)