### PR TITLE
ci: drop --pre-release rc from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
         run: dotnet tool restore
 
       - name: ShipIt (Pull Request)
-        run: dotnet shipit --pre-release rc
+        run: dotnet shipit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- The publish workflow hardcoded `dotnet shipit --pre-release rc`, bypassing the `justfile` recipe.
- That's why the open ShipIt PR (#261) still proposes `5.0.0-rc.5` even though `just shipit` was updated.
- Remove the `--pre-release rc` flag so ShipIt proposes a stable `5.0.0` release next time it runs.

After this merges, ShipIt should regenerate #261 (or open a new PR) targeting `5.0.0` stable.

## Test plan
- [ ] On next push to `main`, the `shipit-pr` job opens a `chore: release 5.0.0` PR (no `-rc.N` suffix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)