### PR TITLE
feat(builtins): make TextIOWrapper enumerable and readline arg optional

### DIFF
--- a/src/stdlib/Builtins.fs
+++ b/src/stdlib/Builtins.fs
@@ -12,13 +12,16 @@ type TextIOBase =
     abstract read: __size: int -> string
     abstract write: __s: string -> int
     abstract writelines: __lines: string seq -> unit
+    abstract readline: unit -> string
     abstract readline: __size: int -> string
+    abstract readlines: unit -> string list
     abstract readlines: __hint: int -> string list
     abstract tell: unit -> int
 
 type TextIOWrapper =
     inherit IDisposable
     inherit TextIOBase
+    inherit IEnumerable<string>
 
 module OpenTextMode =
     [<Literal>]

--- a/test/TestBuiltins.fs
+++ b/test/TestBuiltins.fs
@@ -21,6 +21,38 @@ let ``test write works`` () =
     os.remove tempFile
 
 [<Fact>]
+let ``test TextIOWrapper can be enumerated`` () =
+    let tempFile = os.path.join (os.path.expanduser "~", ".fable_test_iter.txt")
+    let writer = builtins.``open`` (tempFile, OpenTextMode.Write)
+    writer.write "a\nb\nc\n" |> ignore
+    writer.Dispose()
+
+    let lines = ResizeArray<string>()
+    let reader = builtins.``open`` (tempFile, OpenTextMode.Read)
+
+    for line in reader do
+        lines.Add(line.Trim())
+
+    reader.Dispose()
+    os.remove tempFile
+
+    lines |> List.ofSeq |> equal [ "a"; "b"; "c" ]
+
+[<Fact>]
+let ``test readline without argument works`` () =
+    let tempFile = os.path.join (os.path.expanduser "~", ".fable_test_readline.txt")
+    let writer = builtins.``open`` (tempFile, OpenTextMode.Write)
+    writer.write "first\nsecond\n" |> ignore
+    writer.Dispose()
+
+    let reader = builtins.``open`` (tempFile, OpenTextMode.Read)
+    let line = reader.readline ()
+    reader.Dispose()
+    os.remove tempFile
+
+    line.Trim() |> equal "first"
+
+[<Fact>]
 let ``test max with two arguments works`` () =
     builtins.max (3, 5) |> equal 5
     builtins.max (10, 2) |> equal 10


### PR DESCRIPTION
Resolves #131.

## Problem

`builtins.open(...)` returns a `TextIOWrapper`. Two ergonomic gaps were reported:

1. Iterating a file's lines required an untyped cast (`!!result`) to make `for line in result` compile.
2. `readline` forced a size argument (`result.readline(-1)`), but Python's `readline(size=-1)` takes it optionally.

## Changes

`src/stdlib/Builtins.fs`:

- Add `inherit IEnumerable<string>` to `TextIOWrapper`. Per the bindings guide, `IEnumerable<'T>` maps to Python's iterator protocol, so `for line in reader` now compiles directly and types each `line` as `string`. A Python file object is its own iterator, so the generated `get_enumerator(reader)` (→ `iter()`) works at runtime.
- Add zero-arg `readline: unit -> string` and `readlines: unit -> string list` overloads on `TextIOBase`, matching the existing two-overload pattern already used by `read`.

The reporter's snippet now works without the cast:

```fsharp
use reader = builtins.``open`` ("test.txt", OpenTextMode.Read)
for (line: string) in reader do
    builtins.print (line.Trim())
```

## Testing

Added two tests to `test/TestBuiltins.fs` (line enumeration + arg-less `readline`). Full suite passes — **563 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)