### PR TITLE
ci: adopt Paketabot

### DIFF
--- a/.github/workflows/paketabot.yml
+++ b/.github/workflows/paketabot.yml
@@ -1,0 +1,14 @@
+name: Paketabot
+
+on:
+  schedule:
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+jobs:
+  update:
+    uses: cardamomcode/paketabot/.github/workflows/paketabot.yml@v1.0.0
+    permissions:
+      contents: read
+    secrets:
+      paketabot_token: ${{ secrets.PAKETABOT_TOKEN }}


### PR DESCRIPTION
## Summary

- add the weekly and manually dispatchable Paketabot workflow
- pin the reusable workflow to immutable release v1.0.0
- pass the repository's PAKETABOT_TOKEN secret to Paketabot

The repository already contains the root paket.dependencies and paket.lock files required by Paketabot.

## Validation

- git diff --check
- verified the workflow references Paketabot v1.0.0 and PAKETABOT_TOKEN
- verified paket.dependencies and paket.lock are present

The PAKETABOT_TOKEN repository secret has been configured separately.